### PR TITLE
Don't rotate tick labels if self._rotate_tick_labels is False

### DIFF
--- a/circuitpython_simple_dial/simple_dial.py
+++ b/circuitpython_simple_dial/simple_dial.py
@@ -284,6 +284,9 @@ class Dial(displayio.Group):
                 self._dial_radius + self._font_height // 2
             ) * math.cos(this_angle)
 
+            if not self._rotate_tick_labels:
+                this_angle = 0
+
             bitmaptools.rotozoom(
                 self.dial_bitmap,
                 ox=round(target_position_x),


### PR DESCRIPTION
![IMG_3705](https://user-images.githubusercontent.com/6160205/226206518-435410bf-8838-4f9b-8075-dc6b5b3027d5.jpg)
